### PR TITLE
feat: add global typography classes

### DIFF
--- a/src/styles/typography.css
+++ b/src/styles/typography.css
@@ -1,0 +1,88 @@
+/* ========================================
+   TYPOGRAPHY CLASSES
+======================================== */
+
+/* Headings */
+.h1 {
+    font-size: var(--h1-size);
+    font-weight: var(--font-semibold);
+  }
+  
+  .h2 {
+    font-size: var(--h2-size);
+    font-weight: var(--font-semibold);
+  }
+  
+  .h3 {
+    font-size: var(--h3-size);
+    font-weight: var(--font-semibold);
+  }
+  
+  .h4 {
+    font-size: var(--h4-size);
+    font-weight: var(--font-semibold);
+  }
+  
+  .h5 {
+    font-size: var(--h5-size);
+    font-weight: var(--font-semibold);
+  }
+  
+  .h6 {
+    font-size: var(--h6-size);
+    font-weight: var(--font-semibold);
+  }
+  
+  /* Titles */
+  .title-lg {
+    font-size: var(--title-lg);
+    font-weight: var(--font-medium);
+  }
+  
+  .title-md {
+    font-size: var(--title-md);
+    font-weight: var(--font-medium);
+  }
+  
+  .title-sm {
+    font-size: var(--title-sm);
+    font-weight: var(--font-medium);
+  }
+  
+  .title-xs {
+    font-size: var(--title-xs);
+    font-weight: var(--font-medium);
+  }
+  
+  /* Body text */
+  .body-lg {
+    font-size: var(--body-lg);
+    font-weight: var(--font-regular);
+  }
+  
+  .body-md {
+    font-size: var(--body-md);
+    font-weight: var(--font-regular);
+  }
+  
+  .body-sm {
+    font-size: var(--body-sm);
+    font-weight: var(--font-regular);
+  }
+  
+  /* Button text */
+  .btn-text-md {
+    font-size: var(--btn-size-md);
+    font-weight: var(--font-medium);
+  }
+  
+  .btn-text-sm {
+    font-size: var(--btn-size-sm);
+    font-weight: var(--font-medium);
+  }
+  
+  .btn-text-xs {
+    font-size: var(--btn-size-xs);
+    font-weight: var(--font-medium);
+  }
+  


### PR DESCRIPTION
Har lagt till globala CSS-klasser för typografi enligt Figma-designen.

Detta inkluderar:
- Headings: `.h1`–`.h6`
- Titlar: `.title-lg`, `.title-md`, `.title-sm`, `.title-xs`
- Brödtext: `.body-lg`, `.body-md`, `.body-sm`
- Knappar: `.btn-text-md`, `.btn-text-sm`, `.btn-text-xs`

Alla klasser bygger på CSS-variabler definierade i `:root` (i `root.css`).

Klar att användas i komponenter.