### PR TITLE
style: add base styles for primary, secondary and ghost buttons

### DIFF
--- a/src/partials/pages/StyleTest.jsx
+++ b/src/partials/pages/StyleTest.jsx
@@ -1,0 +1,14 @@
+import '../../styles/button.css';
+
+const StyleTest = () => {
+  return (
+    <div style={{ padding: '2rem' }}>
+      <button className="button button-primary" style={{ marginRight: '1rem' }}>Button</button>
+      <button className="button button-secondary" style={{ marginRight: '1rem' }}>Button</button>
+      <button className="button button-ghost">Button</button>
+    </div>
+  );
+};
+
+
+export default StyleTest;

--- a/src/routing/routes.config.jsx
+++ b/src/routing/routes.config.jsx
@@ -4,6 +4,7 @@ import { Navigate } from "react-router-dom";
 import AuthLayout from '../partials/layouts/AuthLayout'
 import PortalLayout from '../partials/layouts/PortalLayout'
 import Unauthorized from "../partials/pages/auth/Unauthorized";
+import StyleTest from '../partials/pages/StyleTest';
 
 const NotFound = lazy(() => import('../partials/pages/NotFound'))
 
@@ -51,5 +52,17 @@ export const routes = [
         children: [
             { path: '*', element: <NotFound /> }
         ]
-    }
+    },
+    // Tillfällig stil-testvy för utveckling
+    {
+        layout: null,
+        adminOnly: false,
+        protected: false,
+        children: [
+          {
+            path: '/style-test',
+            element: <StyleTest />
+          }
+        ]
+      }
 ]

--- a/src/styles/button.css
+++ b/src/styles/button.css
@@ -1,0 +1,50 @@
+.button {
+  font-family: var(--font);
+  font-size: var(--btn-size-md); 
+  font-weight: var(--font-medium);
+  padding: 0.75rem 1.5rem;
+  border-radius: 999px;
+  background-color: var(--primary-100);
+  color: white;
+  border: none;
+  cursor: pointer;
+}
+
+.button-primary {
+    background-color: var(--primary-100);
+    color: white;
+  }
+
+  .button-primary:hover {
+    background-color: var(--primary-90);
+  }  
+  
+  .button-secondary {
+    background-color: var(--secondary-bg-light);
+    color: var(--secondary-100);
+  }
+
+  .button-secondary:hover {
+    background-color: var(--secondary-50);
+  }
+  
+  .button-ghost {
+    background-color: transparent;
+    color: var(--text-color);
+    border: 1px solid var(--grey-40);
+  }
+
+  .button-ghost:hover {
+    background-color: var(--grey-20);
+  }
+
+  .button:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .button:focus-visible {
+    outline: 2px solid var(--primary-50);
+    outline-offset: 2px;
+  }
+  

--- a/src/styles/root.css
+++ b/src/styles/root.css
@@ -39,6 +39,9 @@
     --cool-grey-80: #56565c;
     --cool-grey-90: #39393d;
     --cool-grey-100: #131314;
+
+    /* Semantiska färger */
+    --secondary-bg-light: var(--cool-grey-10);
  
     /* ================================
        STATUS COLORS


### PR DESCRIPTION
Skapat grundläggande CSS-styling för tre knappvarianter:

- `.button-primary`
- `.button-secondary`
- `.button-ghost`

Alla knappar använder variabler från `:root` (färger, typografi, spacing) och innehåller:
- Hover-effekter
- Disabled-styling
- Focus-visible för tillgänglighet

Har även skapat en tillfällig sida `StyleTest.jsx` för att enkelt kunna testa styling framöver. Den är tillgänglig via `/style-test`.

Redo för användning i riktiga komponenter framöver.
