### PR TITLE
feat: lagt till StatBox och uppdaterat AdminDashboard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "react-icons": "^5.5.0",
         "react-router-dom": "^7.5.1"
       },
       "devDependencies": {
@@ -2158,6 +2159,15 @@
       },
       "peerDependencies": {
         "react": "^19.1.0"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
+      "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-router": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-icons": "^5.5.0",
     "react-router-dom": "^7.5.1"
   },
   "devDependencies": {

--- a/src/components/AdminDashboard/StatBox.css
+++ b/src/components/AdminDashboard/StatBox.css
@@ -1,0 +1,42 @@
+.stat-box {
+  background: var(--grey-10); 
+  border-radius: var(--radius-md); 
+  padding: var(--spacing-lg); 
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-md); 
+  box-shadow: var(--shadow-default); 
+  min-width: 200px;
+}
+
+.stat-icon {
+  width: 48px;
+  height: 48px;
+  background: var(--primary-40); 
+  border-radius: var(--radius-lg); 
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--primary-100); 
+}
+
+.stat-content {
+  display: flex;
+  flex-direction: column;
+}
+
+.stat-value {
+  font-size: var(--h4-size); 
+  font-weight: var(--font-bold);
+  margin: 0;
+  color: var(--secondary-110); 
+  line-height: 1.2;
+}
+
+.stat-title {
+  font-size: var(--title-sm); 
+  color: var(--cool-grey-70); 
+  margin: 0;
+  margin-top: var(--spacing-xs); 
+  font-weight: var(--font-medium);
+}

--- a/src/components/AdminDashboard/StatBox.jsx
+++ b/src/components/AdminDashboard/StatBox.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import './StatBox.css';
+import { FaCalendarAlt, FaUserCheck, FaTicketAlt } from 'react-icons/fa';
+
+const stats = [
+  { icon: <FaCalendarAlt size={24} />, title: 'Upcoming Events', value: '345' },
+  { icon: <FaUserCheck size={24} />, title: 'Total Bookings', value: '1798' },
+  { icon: <FaTicketAlt size={24} />, title: 'Tickets Sold', value: '1250' }
+];
+
+const StatBox = () => {
+  return (
+    <div style={{ display: 'flex', gap: '20px' }}>
+      {stats.map((item, index) => (
+        <div className="stat-box" key={index}>
+          <div className="stat-icon">{item.icon}</div>
+          <div className="stat-content">
+            <h3 className="stat-value">{item.value}</h3>
+            <p className="stat-title">{item.title}</p>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default StatBox;

--- a/src/partials/pages/admin/Dashboard.jsx
+++ b/src/partials/pages/admin/Dashboard.jsx
@@ -1,9 +1,12 @@
-import React from 'react'
+import React from 'react';
+import StatBox from '../../../components/AdminDashboard/StatBox';
 
-const Dashboard = () => {
+const AdminDashboard = () => {
   return (
-    <div>Dashboard</div>
-  )
-}
+    <div className="admin-dashboard">
+      <StatBox />
+    </div>
+  );
+};
 
-export default Dashboard
+export default AdminDashboard;

--- a/src/routing/routes.config.jsx
+++ b/src/routing/routes.config.jsx
@@ -1,68 +1,71 @@
-import { lazy } from 'react'
-import { Navigate } from "react-router-dom";
+                            import { lazy } from 'react'
+                            import { Navigate } from "react-router-dom";
 
-import AuthLayout from '../partials/layouts/AuthLayout'
-import PortalLayout from '../partials/layouts/PortalLayout'
-import Unauthorized from "../partials/pages/auth/Unauthorized";
-import StyleTest from '../partials/pages/StyleTest';
+                            import AuthLayout from '../partials/layouts/AuthLayout'
+                            import PortalLayout from '../partials/layouts/PortalLayout'
+                            import Unauthorized from "../partials/pages/auth/Unauthorized";
+                            import StyleTest from '../partials/pages/StyleTest';
 
-const NotFound = lazy(() => import('../partials/pages/NotFound'))
+                            const NotFound = lazy(() => import('../partials/pages/NotFound'))
 
-const SignUp = lazy(() => import('../partials/pages/auth/SignUp'))
-const SignIn = lazy(() => import('../partials/pages/auth/SignIn'))
+                            const SignUp = lazy(() => import('../partials/pages/auth/SignUp'))
+                            const SignIn = lazy(() => import('../partials/pages/auth/SignIn'))
 
-const UserDashboard = lazy(() => import('../partials/pages/user/Dashboard'))
-const UserBookings = lazy(() => import('../partials/pages/user/Bookings'))
+                            const UserDashboard = lazy(() => import('../partials/pages/user/Dashboard'))
+                            const UserBookings = lazy(() => import('../partials/pages/user/Bookings'))
 
-const AdminDashboard = lazy(() => import('../partials/pages/admin/Dashboard'))
-const AdminBookings = lazy(() => import('../partials/pages/admin/Bookings'))
+                            const AdminDashboard = lazy(() => import('../partials/pages/admin/Dashboard'))
+                            const AdminBookings = lazy(() => import('../partials/pages/admin/Bookings'))
 
-export const routes = [
-    {
-        children: [
-            { path: '/',element: <Navigate to="/dashboard" replace /> }
-        ]
-    },
-    {
-        layout: AuthLayout,
-        children: [
-            { path: '/signup', element: <SignUp /> },
-            { path: '/login', element: <SignIn /> },
-            { path: '/denied', element: <Unauthorized /> },
-        ]
-    },
-    {
-        layout: PortalLayout,
-        protected: true,
-        children: [
-            { path: '/dashboard', element: <UserDashboard /> },
-            { path: '/bookings', element: <UserBookings /> },
-        ]
-    },
-    {
-        layout: PortalLayout,
-        protected: true,
-        adminOnly: true,
-        children: [
-            { path: '/admin/dashboard', element: <AdminDashboard /> },
-            { path: '/admin/bookings', element: <AdminBookings /> },
-        ]
-    },
-    {
-        children: [
-            { path: '*', element: <NotFound /> }
-        ]
-    },
-    // Tillfällig stil-testvy för utveckling
-    {
-        layout: null,
-        adminOnly: false,
-        protected: false,
-        children: [
-          {
-            path: '/style-test',
-            element: <StyleTest />
-          }
-        ]
-      }
-]
+                            export const routes = [
+                                {
+                                    children: [
+                                        { path: '/',element: <Navigate to="/dashboard" replace /> }
+                                    ]
+                                },
+                                {
+                                    layout: AuthLayout,
+                                    children: [
+                                        { path: '/signup', element: <SignUp /> },
+                                        { path: '/login', element: <SignIn /> },
+                                        { path: '/denied', element: <Unauthorized /> },
+                                    ]
+                                },
+                                {
+                                    layout: PortalLayout,
+                                    protected: true,
+                                    children: [
+                                        { path: '/dashboard', element: <UserDashboard /> },
+                                        { path: '/bookings', element: <UserBookings /> },
+                                    ]
+                                },
+                                {
+                                    layout: PortalLayout,
+                                    protected: true,
+                                    adminOnly: true,
+                                    children: [
+                                        { path: '/admin/dashboard', element: <AdminDashboard /> },
+                                        { path: '/admin/bookings', element: <AdminBookings /> },
+                                    ]
+                                },
+
+
+                                {
+                                    children: [
+                                        { path: '*', element: <NotFound /> }
+                                    ]
+                                },
+                                
+                                // Tillfällig stil-testvy för utveckling
+                                {
+                                    layout: null,
+                                    adminOnly: false,
+                                    protected: false,
+                                    children: [
+                                    {
+                                        path: '/style-test',
+                                        element: <StyleTest />
+                                    }
+                                    ]
+                                }
+                            ]


### PR DESCRIPTION
Refaktorerat AdminDashboard för att använda en återanvändbar StatBox-komponent.

 Ny komponent:
- `StatBox.jsx` med props för `icon`, `title` och `value`
- Tillhörande styling i `StatBox.css`

 Användning:
- Importeras och används i `AdminDashboard.jsx`
- Ikoner hanteras via `react-icons` (kan ersättas med SVG från Figma vid behov)

 Resultat:
- Dashboarden är nu modulär, tydlig och enklare att expandera.
- Testad via route `/test-dashboard`


