### PR TITLE
Skapa återanvändbar Header-komponent

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "lucide-react": "^0.503.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-icons": "^5.5.0",
@@ -1941,6 +1942,15 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/lucide-react": {
+      "version": "0.503.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.503.0.tgz",
+      "integrity": "sha512-HGGkdlPWQ0vTF8jJ5TdIqhQXZi6uh3LnNgfZ8MHiuxFfX3RZeA79r2MW2tHAZKlAVfoNE8esm3p+O6VkIvpj6w==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
     },
     "node_modules/minimatch": {
       "version": "3.1.2",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "lucide-react": "^0.503.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-icons": "^5.5.0",

--- a/src/components/Header/Header.css
+++ b/src/components/Header/Header.css
@@ -1,0 +1,124 @@
+.header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: var(--spacing-lg);
+    background-color: var(--grey-20);
+    border-bottom: 1px solid var(--grey-30);
+  }
+  
+  .header-left {
+    display: flex;
+    flex-direction: column;
+  }
+  
+  .breadcrumb {
+    font-size: var(--title-xs);
+    font-weight: var(--font-medium);
+    margin-bottom: 4px;
+    color: var(--grey-60);
+  }
+
+  .breadcrumb span {
+    color: var(--primary-100);
+    margin-right: 0.25rem;
+  }
+  
+  .page-title {
+    color: var(--secondary-100);
+    font-size: var(--h2-size);
+    font-weight: var(--font-semibold);
+    margin: 0;
+  }
+  
+  .header-right {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-md);
+  }
+  
+  .search {
+    position: relative;
+    width: 307px;
+    height: 40px;
+  }
+  
+  .search input {
+    width: 100%;
+    height: 100%;
+    border: none;
+    outline: none;
+    background-color: white;
+    padding: 0 2.5rem 0 1rem; 
+    border-radius: 999px;
+    font-size: 14px;
+    color: var(--text-color);
+    box-sizing: border-box;
+  }
+  
+  .search-icon {
+    position: absolute;
+    right: 1rem;
+    top: 50%;
+    transform: translateY(-50%);
+    color: var(--grey-90);
+    pointer-events: none;
+  }
+  
+  .icon-button {
+    background-color: var(--secondary-100);
+    color: white;
+    border-radius: 50%;
+    width: 40px;
+    height: 40px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    border: none;
+    cursor: pointer;
+  }
+
+  .icon-button:hover {
+    background-color: var(--secondary-90);
+    transition: background-color 0.2s ease-in-out;
+  }
+
+  .has-notification {
+    position: relative;
+  }
+  
+  .notification-dot {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    width: 8px;
+    height: 8px;
+    background-color: var(--primary-100);
+    border-radius: 50%;
+  }  
+  
+  .user-info {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-sm);
+  }
+  
+  .user-avatar {
+    width: 40px;
+    height: 40px;
+    background-color: var(--cool-grey-10);
+    border-radius: 50%;
+  }
+  
+  .user-name {
+    color: var(--secondary-110);
+    font-weight: var(--font-medium);
+    margin: 0;
+  }
+  
+  .user-role {
+    font-size: var(--body-sm);
+    color: var(--grey-60);
+    margin: 0;
+  }
+  

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -1,0 +1,60 @@
+import './Header.css';
+import { Bell, Settings, Search } from 'lucide-react';
+
+/**
+ * Props:
+ * - title: huvudrubrik (t.ex. "Dashboard", "Bookings")
+ * - breadcrumb: valfri breadcrumb-text, visas som "Dashboard / [breadcrumb]"
+ */
+
+// TODO: Gör breadcrumb dynamisk utifrån aktuell sida när routing är på plats
+// TODO: Gör notification-dot togglable via props
+
+const Header = ({ title = 'Dashboard', breadcrumb }) => {
+  return (
+    <header className="header">
+      <div className="header-left">
+        {breadcrumb && (
+          <p className="breadcrumb">
+            <span>Dashboard</span> / {breadcrumb}
+          </p>
+        )}
+        <h1 className="page-title">{title}</h1>
+      </div>
+
+      <div className="header-right">
+        <div className="search">
+          <input
+            type="text"
+            placeholder="Search anything"
+            aria-label="Search"
+          />
+          <Search size={18} className="search-icon" />
+        </div>
+
+        <button
+          className="icon-button has-notification"
+          aria-label="Notifications"
+        >
+          <Bell size={20} />
+          <span className="notification-dot"></span>
+        </button>
+
+        <button className="icon-button" aria-label="Settings">
+          <Settings size={20} />
+        </button>
+
+        <div className="user-info">
+          <div className="user-avatar" />
+          <div>
+            <p className="user-name">Orlando Laurentius</p>
+            <p className="user-role">Admin</p>
+          </div>
+        </div>
+      </div>
+    </header>
+  );
+};
+
+export default Header;
+

--- a/src/partials/pages/StyleTest.jsx
+++ b/src/partials/pages/StyleTest.jsx
@@ -1,8 +1,14 @@
 import '../../styles/button.css';
+import Header from '../../components/Header/Header';
 
 const StyleTest = () => {
   return (
-    <div style={{ padding: '2rem' }}>
+    <div>
+      <Header
+        title="Dashboard"
+        breadcrumb="Dashboard"
+      />
+
       <button className="button button-primary" style={{ marginRight: '1rem' }}>Button</button>
       <button className="button button-secondary" style={{ marginRight: '1rem' }}>Button</button>
       <button className="button button-ghost">Button</button>
@@ -10,5 +16,5 @@ const StyleTest = () => {
   );
 };
 
-
 export default StyleTest;
+


### PR DESCRIPTION
Denna pull request lägger till en återanvändbar <Header />-komponent enligt designen i Figma. Komponenten innehåller:

-     Dynamisk titel via prop (title)
-     Valfri breadcrumb via prop (breadcrumb)
-     Sökfält med integrerad ikon
-     Ikonknappar för notiser och inställningar (Lucide)
-     Användaravatar + namn/roll (hårdkodat för nu)

Komponenten är testad i /style-test och är inte ännu kopplad till någon riktig sida/layout.
Noteringar:

- lucide-react har installerats som dependency → kör npm install efter att denna PR är mergad
- Breadcrumb och notification-dot är temporärt hårdkodade och markerade med TODO:-kommentarer
- Responsivitet och placering i layout hanteras i separat branch