### PR TITLE
Gör användarinformation i Header dynamisk via props

### DIFF
--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -5,12 +5,15 @@ import { Bell, Settings, Search } from 'lucide-react';
  * Props:
  * - title: huvudrubrik (t.ex. "Dashboard", "Bookings")
  * - breadcrumb: valfri breadcrumb-text, visas som "Dashboard / [breadcrumb]"
+ * - userName: namn på inloggad användare (t.ex. "Orlando Laurentius")
+ * - userRole: roll för inloggad användare (t.ex. "Admin")
  */
 
 // TODO: Gör breadcrumb dynamisk utifrån aktuell sida när routing är på plats
 // TODO: Gör notification-dot togglable via props
+// TODO: Koppla userName och userRole till auth/data när användarinloggning är på plats
 
-const Header = ({ title = 'Dashboard', breadcrumb }) => {
+const Header = ({ title = 'Dashboard', breadcrumb, userName = 'Orlando Laurentius', userRole = 'Admin' }) => {
   return (
     <header className="header">
       <div className="header-left">
@@ -47,8 +50,8 @@ const Header = ({ title = 'Dashboard', breadcrumb }) => {
         <div className="user-info">
           <div className="user-avatar" />
           <div>
-            <p className="user-name">Orlando Laurentius</p>
-            <p className="user-role">Admin</p>
+            <p className="user-name">{userName}</p>
+            <p className="user-role">{userRole}</p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Har gjort användarnamn och roll i Header-komponenten dynamiska genom att lägga till props userName och userRole.
Har uppdaterat StyleTest för att testa de nya propsen.
Lagt till en TODO för framtida koppling mot auth/data.

Props: title, breadcrumb, userName, userRole
Header fungerar som tidigare om inga props skickas (defaultvärden satta).