### PR TITLE
feat: add initial PortalLayout with responsive structure and Header

### DIFF
--- a/src/partials/layouts/PortalLayout.css
+++ b/src/partials/layouts/PortalLayout.css
@@ -1,0 +1,52 @@
+.portal-layout {
+  display: flex;
+  min-height: 100vh;
+  background-color: var(--background-color);
+  padding: var(--spacing-base); 
+  box-sizing: border-box;
+  width: 100%;
+}
+
+.sidebar {
+  width: 223px;
+  background-color: var(--secondary-bg-light);
+  border-radius: var(--radius-lg); 
+  margin-right: var(--spacing-base); 
+  padding: var(--spacing-base); 
+}
+
+.content-area {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-base); 
+}
+
+header.header {
+  min-height: 90px;
+  border-radius: var(--radius-lg); 
+  padding: var(--spacing-md) var(--spacing-xl); 
+}
+
+main {
+  background-color: var(--grey-20);
+  border-radius: var(--radius-lg); 
+  padding: var(--spacing-base); 
+  flex: 1;
+}
+
+@media (max-width: 768px) {
+  .portal-layout {
+    flex-direction: column;
+  }
+
+  .sidebar {
+    width: 100%;
+    margin-right: 0;
+    margin-bottom: var(--spacing-md);
+  }
+
+  .content-area {
+    width: 100%;
+  }
+}

--- a/src/partials/layouts/PortalLayout.jsx
+++ b/src/partials/layouts/PortalLayout.jsx
@@ -1,12 +1,21 @@
 import React from 'react'
 import { Outlet } from 'react-router-dom'
 import Header from '../../components/Header/Header'
+import './PortalLayout.css'
 
 const PortalLayout = () => {
   return (
     <div className="portal-layout">
-      <Header title="Dashboard" />
-      <Outlet />
+      <aside className="sidebar">
+        {/* <Navbar /> */}
+      </aside>
+
+      <div className="content-area">
+        <Header title="Dashboard" />
+        <main>
+          <Outlet />
+        </main>
+      </div>
     </div>
   );
 };

--- a/src/styles/root.css
+++ b/src/styles/root.css
@@ -88,6 +88,7 @@
     ================================= */
     --spacing-xs: 4px;
     --spacing-sm: 8px;
+    --spacing-base: 12px;
     --spacing-md: 16px;
     --spacing-lg: 24px;
     --spacing-xl: 32px;


### PR DESCRIPTION
Lade till grundläggande portal-layout med PortalLayout-komponenten.

 Innehåll:

- Struktur för layout: .portal-layout, .sidebar och .content-area
- Header-komponenten laddas korrekt med titel "Dashboard"
- <Outlet /> för sidinnehåll
- Grundläggande responsivitet med media queries
- Använder CSS-variabler för spacing och radius

Övrigt:

- Navbar är ännu inte implementerad – kommer i separat branch
- Layouten är i linje med designen i Figma för desktop och mobil