### PR TITLE
feat: render navbar links based on user role

### DIFF
--- a/src/components/Navbar/Navbar.jsx
+++ b/src/components/Navbar/Navbar.jsx
@@ -1,21 +1,30 @@
-import React from 'react';
 import './Navbar.css';
-import { LayoutDashboard, CheckSquare, Ticket, LogOut } from 'lucide-react';
+import { LayoutDashboard, CalendarDays, Ticket, CheckSquare, CreditCard, LogOut } from 'lucide-react';
 import VentixeLogo from '../../assets/ventixe-logo.svg';
 
-const Navbar = () => {
+// TODO: Byt ut isAdmin-prop mot faktisk roll från autentisering när auth är på plats
+const Navbar = ({ isAdmin = false }) => {
   return (
     <nav className="navbar">
       <div className="navbar-top">
         <div className="logo">
-          <img src={VentixeLogo} alt="Ventixe Logo" className="logo-img" />
+          <img src={VentixeLogo} alt="Ventixe logo" className="logo-img" />
         </div>
-          <ul className="nav-links">
-            <li><LayoutDashboard size={18} /> Dashboard</li>
-            <li><CheckSquare size={18} /> Bookings</li>
-            <li><Ticket size={18} /> Events</li>
-          </ul>
+        <ul className="nav-links">
+          <li><LayoutDashboard size={18} /> Dashboard</li>
+          <li><CalendarDays size={18} /> Events</li>
+
+          {isAdmin ? (
+            <>
+              <li><CheckSquare size={18} /> Bookings</li>
+              <li><CreditCard size={18} /> Invoices</li>
+            </>
+          ) : (
+            <li><Ticket size={18} /> Your tickets</li>
+          )}
+        </ul>
       </div>
+
       <div className="navbar-bottom">
         <button className="sign-out-btn">
           <LogOut size={18} />
@@ -27,3 +36,4 @@ const Navbar = () => {
 };
 
 export default Navbar;
+


### PR DESCRIPTION
Visar olika menyval i navbaren beroende på användarroll.
Om ``isAdmin`` är true visas adminlänkar (Bookings, Invoices), annars visas användarlänken "Your tickets".
Roll hanteras tillfälligt via en prop tills autentisering är på plats.