### PR TITLE
fix: make Header title and breadcrumb dynamic

### DIFF
--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -3,8 +3,11 @@ import { Bell, Settings, Search } from 'lucide-react';
 import { useLocation } from 'react-router-dom';
 
 /**
+ * - Dynamisk breadcrumb och sidrubrik baserat på aktuell URL-path
+ * - Inloggad användares namn och roll (placeholder tills auth är på plats)
+ * - Sökfält samt ikoner för notifikationer och inställningar
+ *
  * Props:
- * - title: huvudrubrik (t.ex. "Dashboard", "Bookings")
  * - userName: namn på inloggad användare (t.ex. "Orlando Laurentius")
  * - userRole: roll för inloggad användare (t.ex. "Admin")
  * - hasNotification: boolean som styr om en notification-dot ska visas (true = visa, false = göm)
@@ -14,15 +17,25 @@ import { useLocation } from 'react-router-dom';
  */
 
 const breadcrumbMap = {
-  '/dashboard': null, 
-  '/bookings': 'Bookings',
+  '/dashboard': null,
+  '/events': 'Events',
+  '/your-tickets': 'Your Tickets',
+
   '/admin/dashboard': 'Admin Dashboard',
   '/admin/bookings': 'Admin Bookings',
+  '/admin/events': 'Admin Events',
+  '/admin/invoices': 'Admin Invoices',
 };
 
-const Header = ({ title = 'Dashboard', userName = 'Orlando Laurentius', userRole = 'Admin', hasNotification = false }) => {
+
+const Header = ({
+  userName = 'Orlando Laurentius',
+  userRole = 'Admin',
+  hasNotification = false
+}) => {
   const location = useLocation();
   const breadcrumb = breadcrumbMap[location.pathname] || null;
+  const title = breadcrumb || 'Dashboard';
 
   return (
     <header className="header">


### PR DESCRIPTION
- Gjorde om <Header /> så att både breadcrumb och sidtitel sätts dynamiskt baserat på location.pathname.
- Uppdaterade kommentaren i Header-komponenten för att bättre spegla nuvarande implementation.