### PR TITLE
style: highlight active route in navbar

### DIFF
--- a/src/components/Navbar/Navbar.css
+++ b/src/components/Navbar/Navbar.css
@@ -8,23 +8,28 @@
 .navbar-top {
   display: flex;
   flex-direction: column;
+  align-items: center;
   gap: var(--spacing-md);
 }
 
 .logo {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
   margin-bottom: var(--spacing-lg);
 }
 
 .logo-img {
   width: auto;
+  height: 32px;
   display: block;
 }
-
 
 .nav-links {
   display: flex;
   flex-direction: column;
   gap: var(--spacing-md);
+  position: relative;
 }
 
 .nav-links a {
@@ -34,8 +39,31 @@
   cursor: pointer;
   color: var(--secondary-100);
   font-weight: var(--font-medium);
+  position: relative;
+  padding: var(--spacing-sm) var(--spacing-lg) var(--spacing-sm) var(--spacing-xl);
 }
 
+.nav-links a.active {
+  color: var(--primary-100);
+  font-weight: var(--font-medium);
+  position: relative;
+}
+
+.nav-links a.active svg {
+  stroke: var(--primary-100);
+}
+
+.nav-links a.active::before {
+  content: '';
+  position: absolute;
+  left: 0px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 4px;
+  height: 24px;
+  background-color: var(--primary-90);
+  border-radius: var(--radius-sm);
+}
 
 .sign-out-btn {
   display: flex;


### PR DESCRIPTION
Lade till en rosa indikator och färgmarkering för aktiv sida i navbaren, enligt Figma. Justeringen fungerar för både Admin- och User-vy. Indikatorn är visuellt korrekt placerad, även om den inte är pixelperfekt mot kanten. Kan förbättras senare vid behov.