### PR TITLE
Merge event-filter (filter UI & logic) into event-cards (card display improvements)

### DIFF
--- a/src/components/Events/EventCard.css
+++ b/src/components/Events/EventCard.css
@@ -1,184 +1,302 @@
 /* === GEMENSAMT FÖR ALLA EVENT-KORT === */
 
 .event-card {
-    background-color: var(--grey-10);
-    border-radius: var(--radius-lg);
-    box-shadow: var(--shadow-default);
-    overflow: hidden;
-    transition: box-shadow 0.2s ease;
-    cursor: pointer;
-    display: flex;
-    flex-direction: column;
-  }
-  
-  .event-card:hover {
-    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1);
-  }
-  
-  /* === BILD === */
-  .event-image-wrapper {
-    position: relative;
-    width: 100%;
-    height: 180px;
-    overflow: hidden;
-  }
-  
-  .event-card.list .event-image-wrapper {
-    width: 200px;
-    height: 100%;
-    flex-shrink: 0;
-  }
-  
-  .event-image {
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-  }
-  
-  /* === TAGGAR (Kategori & Status) === */
-  .event-tags {
-    position: absolute;
-    top: var(--spacing-sm);
-    left: var(--spacing-sm);
-    display: flex;
-    gap: 100px;
-  }
-  
-  .category-badge,
-  .status-badge {
-    padding: 4px 10px;
-    border-radius: var(--radius-md);
-    font-size: var(--btn-size-xs);
-    font-weight: var(--font-medium);
-  }
-  
-  .category-badge {
-    background-color: var(--cool-grey-20);
-    color: var(--secondary-100);
-  }
-  
-  .status-badge {
-    color: var(--cool-grey-100);
-  }
-  
-  .status-badge.active {
-    background-color: var(--status-confirmed);
-  }
-  
-  .status-badge.draft {
-    background-color: var(--status-pending);
-  }
-  
-  .status-badge.past {
-    background-color: var(--status-cancelled);
-  }
-  
-  
-  /* === INFO === */
-  .event-info {
-    padding: var(--spacing-md);
-    display: flex;
-    flex-direction: column;
-    gap: var(--spacing-xs);
-  }
-  
-  .event-title {
-    font-size: var(--h5-size);
-    font-weight: var(--font-semibold);
-    color: var(--text-color);
-  }
-  
-  .event-date,
-  .event-location {
-    font-size: var(--body-sm);
-    color: var(--cool-grey-80);
-  }
-  
-  /* === META (pris & säljinformation) === */
-  .event-meta {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-top: var(--spacing-sm);
-  }
-  
-  .price {
-    font-size: var(--title-md);
-    color: var(--primary-100);
-    font-weight: var(--font-bold);
-  }
-  
-  .progress-bar-wrapper {
-    background-color: var(--cool-grey-30);
-    height: 8px;
-    width: 100px;
-    border-radius: var(--radius-md);
-    overflow: hidden;
-    position: relative;
-  }
-  
-  .progress-bar {
-    height: 100%;
-    background-color: var(--primary-100);
-    transition: width 0.3s ease;
-  }
-  
-  .percentage {
-    font-size: var(--body-sm);
-    margin-left: var(--spacing-sm);
-  }
-  
-  /* === ADMIN-KNAPPAR === */
-  .event-actions {
-    display: flex;
-    justify-content: flex-end;
-    gap: var(--spacing-sm);
-    padding: var(--spacing-sm) var(--spacing-md);
-    border-top: 1px solid var(--grey-30);
-  }
-  
-  .btn-edit,
-  .btn-delete {
-    font-size: var(--btn-size-sm);
-    padding: 4px 10px;
-    border-radius: var(--radius-sm);
-    border: none;
-    cursor: pointer;
-    transition: background 0.2s ease;
-  }
-  
-  .btn-edit {
-    background-color: var(--secondary-100);
-    color: white;
-  }
-  
-  .btn-edit:hover {
-    background-color: var(--secondary-90);
-  }
-  
-  .btn-delete {
-    background-color: var(--cool-grey-30);
-    color: var(--grey-100);
-  }
-  
-  .btn-delete:hover {
-    background-color: var(--cool-grey-50);
-  }
-  
-  /* === LAYOUT FÖR LIST-VY === */
-  .event-card.list {
-    flex-direction: row;
-    align-items: stretch;
-  }
-  
-  .event-card.list .event-info {
-    flex: 1;
-    padding: var(--spacing-lg);
-  }
-  
-  .event-card.list .event-meta {
-    margin-top: var(--spacing-sm);
-  }
+  background-color: var(--grey-10);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-default);
+  overflow: hidden;
+  transition: box-shadow 0.2s ease;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  width: 280px; 
+}
+
+.event-card:hover {
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.08);
+}
+
+/* === BILD === */
+.event-image-wrapper {
+  position: relative;
+  width: 95%;
+  height: 200px;
+  top: var(--spacing-sm);
+  left: var(--spacing-sm);
+  bottom: var(--spacing-sm);
+  background-color: var(--grey-40);
+  border-radius: 5%;
+  overflow: hidden;
+  border-bottom: 1px solid var(--grey-30);
+}
+
+.event-image {
+  width: 100%;
+  height: 100%;
+  border-radius: 5%;
+}
+
+/* === TAGGAR (Kategori & Status) === */
+.event-tags {
+  position: absolute;
+  top: var(--spacing-sm);
+  left: var(--spacing-sm);
+  right: var(--spacing-sm);
+  display: flex;
+  justify-content: space-between;
+  width: calc(100% - 2 * var(--spacing-sm));
+  z-index: 1;
+
+}
+
+.category-badge,
+.status-badge {
+  padding: 4px 12px;
+  border-radius: 12px;
+  font-size: var(--btn-size-xs);
+  font-weight: var(--font-medium);
+}
+
+.category-badge {
+  background-color: var(--cool-grey-20);
+  color: var(--secondary-100);
+}
+
+.status-badge {
+  color: var(--cool-grey-100);
+}
+
+.status-badge.active {
+  background-color: var(--status-confirmed);
+}
+
+.status-badge.draft {
+  background-color: var(--status-pending);
+}
+
+.status-badge.past {
+  background-color: var(--status-cancelled);
+}
+
+/* === INFO === */
+.event-info {
+  padding: var(--spacing-md);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+}
+
+.event-title {
+  font-size: var(--h8-size);
+  font-weight: var(--font-semibold);
+  color: var(--text-color);
+  margin: 0;
+}
+
+.event-date,
+.event-location {
+  font-size: var(--body-sm);
+  color: var(--cool-grey-80);
+  margin: 0;
+}
+
+/* === META (pris & säljinformation) === */
+.event-meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: var(--spacing-sm);
+}
+
+.event-price {
+  font-size: var(--title-md);
+  color: var(--primary-100);
+  font-weight: var(--font-bold);
+}
+
+.progress-bar-wrapper {
+  background-color: var(--cool-grey-30);
+  height: 8px;
+  width: 100px;
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  position: relative;
+}
+
+.progress-bar {
+  height: 100%;
+  background-color: var(--primary-100);
+  transition: width 0.3s ease;
+}
+
+.percentage {
+  font-size: var(--body-sm);
+  font-weight: var(--font-semibold);
+  margin-left: -65px;
+  color: var(--text-color);
+}
+
+/* === ADMIN-KNAPPAR === */
+.event-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-sm) var(--spacing-md);
+  border-top: 1px solid var(--grey-30);
+}
+
+.btn-edit,
+.btn-delete {
+  font-size: var(--btn-size-sm);
+  padding: 6px 12px;
+  border-radius: 12px;
+  border: none;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.btn-edit {
+  background-color: var(--secondary-100);
+  color: white;
+}
+
+.btn-edit:hover {
+  background-color: var(--secondary-90);
+}
+
+.btn-delete {
+  background-color: var(--cool-grey-30);
+  color: var(--grey-100);
+}
+
+.btn-delete:hover {
+  background-color: var(--cool-grey-50);
+}
+
+/* === LAYOUT FÖR LIST-VY === */
+.event-card.list {
+  flex-direction:row;
+  align-items: stretch;
+  width: 100%;
+}
+
+.event-card.list .event-image-wrapper {
+  width: 200px;
+  height: 100%;
+  flex-shrink: 0;
+}
+
+.event-card.list .event-info {
+  flex: 1;
+  padding: var(--spacing-lg);
+}
+
+.event-card.list .event-meta {
+  margin-top: var(--spacing-sm);
+}
+
+.event-card.list .event-date-row{
+  max-width:fit-content;
+ 
+}
+
+.event-card.list .event-meta{
+  max-width:fit-content;
+  margin-left: 1000px;
+
+}
+
+.event-card.list .event-location{
+   max-width:fit-content;
+  margin-left: 500px;
+}
+
+.event-card.list .event-price{
+ max-width:fit-content;
+ margin-left: 500px;
+ background-color: var(--cool-grey-10);
+ border-radius:10%;
+ padding: 0.5rem 0.5rem;
+ 
+}
+
+.event-card.list .percentage{
+ max-width:fit-content;
+ margin-left: 10px;
+ border-radius:10%;
+ padding: 0.5rem 0.5rem;
+ 
+}
+
+.event-card.list .ellipsis-button{
+ max-width:fit-content;
+ margin-left: 500px;
 
  
+}
+
+/* === ELLIPS-KNAPP === */
+
+.event-date-row {
+  position: relative;
+  display: flex;
+  align-items: center;
+  min-height: 24px;
+}
+
+.event-options-wrapper {
+  position: absolute;
+  top: 0;
+  right: 0;
+  display: inline-block;
+  z-index: 5;
+}
+
+.menu-wrapper {
+  position: absolute;
+  top: var(--spacing-sm);
+  right: var(--spacing-sm);
+}
+
+.ellipsis-button {
+  background: transparent;
+  border: none;
+  font-size: 30px;
+  color: var(--primary-100);
+  cursor: pointer;
+  padding: 0;
+}
+
+.ellipsis-button:hover {
+  color:var(--primary-50);
   
+}
+
+.card-menu {
+  position: absolute;
+  top: 36px;
+  right: 0;
+  background-color: var(--grey-10);
+  border: 1px solid var(--grey-30);
+  border-radius: var(--radius-sm);
+  box-shadow: var(--shadow-default);
+  z-index: 10;
+  display: flex;
+  flex-direction: column;
+}
+
+.card-menu button {
+  padding: 8px 12px;
+  border: none;
+  background: none;
+  text-align: left;
+  cursor: pointer;
+  font-size: var(--body-sm);
+  color: var(--text-color);
+}
+
+.card-menu button:hover {
+  background-color: var(--grey-20);
+  transition: background 0.5s ease;
+
+}

--- a/src/components/Events/EventCard.jsx
+++ b/src/components/Events/EventCard.jsx
@@ -1,7 +1,9 @@
-import React from "react";
+import React, { useState } from "react";
 import "./EventCard.css";
 
 const EventCard = ({ event, isAdmin, viewMode = "grid", onEdit, onDelete, onClick }) => {
+  const [menuOpen, setMenuOpen] = useState(false);
+
   const {
     eventName,
     category,
@@ -11,7 +13,7 @@ const EventCard = ({ event, isAdmin, viewMode = "grid", onEdit, onDelete, onClic
     startDateTime,
     ticketsSold,
     totalTickets,
-    imageUrl
+    imageUrl,
   } = event;
 
   const percentageSold = Math.round((ticketsSold / totalTickets) * 100);
@@ -27,10 +29,39 @@ const EventCard = ({ event, isAdmin, viewMode = "grid", onEdit, onDelete, onClic
       </div>
 
       <div className="event-info">
-        <p className="event-date">
-          {new Date(startDateTime).toLocaleDateString()} –{" "}
-          {new Date(startDateTime).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}
-        </p>
+        <div className="event-date-row">
+          <p className="event-date">
+            {new Date(startDateTime).toLocaleDateString("en-US", {
+                  year: "numeric",
+                  month: "long",
+                  day: "numeric"
+                })}{" "}
+                –{" "}
+                {new Date(startDateTime).toLocaleTimeString("en-US", {
+                  hour: "numeric",
+                  minute: "2-digit",
+                  hour12: true
+                })}
+          </p>
+
+          {isAdmin && (
+            <div className="event-options-wrapper" onClick={(e) => e.stopPropagation()}>
+              <button
+                className="ellipsis-button"
+                onClick={() => setMenuOpen((prev) => !prev)}
+              >
+                ...
+              </button>
+              {menuOpen && (
+                <div className="card-menu">
+                  <button onClick={() => onEdit?.(event.id)}>Edit</button>
+                  <button onClick={() => onDelete?.(event.id)}>Delete</button>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+
         <h3 className="event-title">{eventName}</h3>
         <p className="event-location">{location}</p>
 
@@ -41,32 +72,10 @@ const EventCard = ({ event, isAdmin, viewMode = "grid", onEdit, onDelete, onClic
           <span className="percentage">{percentageSold}%</span>
           <div className="event-price">${price}</div>
         </div>
-
-        {isAdmin && (
-          <div className="event-actions">
-            <button
-              className="btn-edit"
-              onClick={(e) => {
-                e.stopPropagation();
-                onEdit?.(event.id);
-              }}
-            >
-              Edit
-            </button>
-            <button
-              className="btn-delete"
-              onClick={(e) => {
-                e.stopPropagation();
-                onDelete?.(event.id);
-              }}
-            >
-              Delete
-            </button>
-          </div>
-        )}
       </div>
     </div>
   );
 };
+
 
 export default EventCard;

--- a/src/components/Events/EventFilters.css
+++ b/src/components/Events/EventFilters.css
@@ -1,0 +1,107 @@
+.filters-wrapper {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 0;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.status-filters {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.status-button {
+  background-color: var(--grey-10);
+  border: none;
+  border-radius: 999px;
+  padding: 0.4rem 1rem;
+  font-size: 0.9rem;
+  color: var(--text-color);
+  cursor: pointer;
+  font-weight: 500;
+   box-shadow: var(--shadow-default);
+}
+
+.status-button.active {
+  background-color: var(--primary-100);
+  color: white;
+}
+
+
+.status-button span {
+  opacity: 0.6;
+  font-weight: normal;
+  margin-left: 4px;
+}
+
+.search-and-filters {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.search-wrapper {
+  position: relative;
+}
+
+.search-input {
+  padding: 0.5rem 2rem 0.5rem 1rem;
+  border-radius: 999px;
+  border: none;
+  background-color: white;
+  box-shadow: var(--shadow-default);
+  min-width: 240px;
+}
+
+.search-icon {
+  position: absolute;
+  right: 0.75rem;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--cool-grey-80);
+}
+
+.icon-button,
+.dropdown-button {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.4rem 0.8rem;
+  background-color: var(--cool-grey-10);
+  border-radius: 999px;
+  border: none;
+  cursor: pointer;
+  font-size: 0.85rem;
+  color: var(--text-color);
+}
+
+.icon-button {
+  background-color: var(--secondary-100);
+  color: white;
+  padding: 0.4rem;
+  border-radius: 50%;
+  width: 36px;
+  height: 36px;
+  justify-content: center;
+}
+
+.icon-toggle {
+  background-color: var(--cool-grey-10);
+  border: none;
+  border-radius: 50%;
+  padding: 0.4rem;
+  cursor: pointer;
+  width: 36px;
+  height: 36px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  color: var(--text-color);
+}
+
+.icon-toggle.active {
+  background-color: var(--secondary-100);
+  color: white;
+}

--- a/src/components/Events/EventFilters.jsx
+++ b/src/components/Events/EventFilters.jsx
@@ -1,0 +1,69 @@
+import React from "react";
+import {
+  Search,
+  SlidersHorizontal,
+  CalendarDays,
+  LayoutGrid,
+  Menu,
+  ChevronDown,
+} from "lucide-react";
+import "./EventFilters.css";
+
+const EventFilters = ({ viewMode, onViewModeChange, statusFilter, onStatusFilterChange, statusCounts }) => {
+  return (
+    <div className="filters-wrapper">
+      <div className="status-filters">
+        {["Active", "Draft", "Past"].map((status) => (
+            <button
+            key={status}
+            className={`status-button ${statusFilter === status ? "active" : ""}`}
+            onClick={() => onStatusFilterChange(status)}
+            >
+            {status}{" "}
+            <span>
+                ({statusCounts[status] || 0})
+            </span>
+            </button>
+        ))}
+      </div>
+
+
+      <div className="search-and-filters">
+        <div className="search-wrapper">
+          <input
+            type="text"
+            placeholder="Search event, location, etc"
+            className="search-input"
+          />
+          <Search className="search-icon" size={16} />
+        </div>
+
+        <button className="icon-button">
+          <SlidersHorizontal size={16} />
+        </button>
+
+        <button className="dropdown-button">
+          <CalendarDays size={16} />
+          <span>This Month</span>
+          <ChevronDown size={16} />
+        </button>
+
+        <button
+          className={`icon-toggle ${viewMode === "grid" ? "active" : ""}`}
+          onClick={() => onViewModeChange("grid")}
+        >
+          <LayoutGrid size={16} />
+        </button>
+
+        <button
+          className={`icon-toggle ${viewMode === "list" ? "active" : ""}`}
+          onClick={() => onViewModeChange("list")}
+        >
+          <Menu size={16} />
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default EventFilters;

--- a/src/partials/pages/admin/Events.css
+++ b/src/partials/pages/admin/Events.css
@@ -1,27 +1,34 @@
-/* Container för hela sidan */
+/* === CONTAINER === */
 .events-container {
-    padding: var(--spacing-xl);
-  }
-  
-  /* Titel + vyväxlarens wrapper */
-  .events-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-bottom: var(--spacing-lg);
-  }
-  
-  /* Gridvy med kort */
-  .event-grid {
-    display: grid;
-    grid-template-columns: repeat(4, 1fr);
-    gap: var(--spacing-lg);
-  }
-  
-  /* Listvy */
-  .event-list {
-    display: flex;
-    flex-direction: column;
-    gap: var(--spacing-md);
-  }
-  
+  padding: var(--spacing-xl);
+  min-height: 100vh;
+}
+
+/* === HEADER (titel + vyväxlare) === */
+.events-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: var(--spacing-lg);
+}
+
+.events-header h1 {
+  font-size: var(--h2-size);
+  font-weight: var(--font-semibold);
+  margin: 0;
+}
+
+/* === GRID-VY === */
+.event-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 1.5rem;
+  justify-content: start;
+}
+
+/* === LISTVY === */
+.event-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+}

--- a/src/partials/pages/admin/Events.jsx
+++ b/src/partials/pages/admin/Events.jsx
@@ -1,13 +1,14 @@
 import React, { useEffect, useState } from "react";
 import EventCard from "../../../components/Events/EventCard";
-import './Events.css';
-
+import EventFilters from "../../../components/Events/EventFilters";
+import "./Events.css";
 
 const Events = () => {
   const [events, setEvents] = useState([]);
-  const [viewMode, setViewMode] = useState("grid"); // grid eller listvy
+  const [viewMode, setViewMode] = useState("grid");
+  const [statusFilter, setStatusFilter] = useState("Active");
 
-  // Hämta (mockade) eventdata efter komponenten mountas
+
   useEffect(() => {
     const timer = setTimeout(() => {
       setEvents([
@@ -30,10 +31,10 @@ const Events = () => {
           startDateTime: "2025-07-01T18:30:00",
           location: "Göteborg",
           price: 499,
-          status: "Draft",
+          status: "Active",
           ticketsSold: 65,
           totalTickets: 200,
-          imageUrl: "/assets/images/adventure.jpg",
+          imageUrl: "/src/assets/Testbild.jpg",
         },
         {
           id: "3",
@@ -42,10 +43,10 @@ const Events = () => {
           startDateTime: "2025-06-20T19:00:00",
           location: "Malmö",
           price: 199,
-          status: "Past",
+          status: "Draft",
           ticketsSold: 65,
           totalTickets: 200,
-          imageUrl: "/assets/images/adventure.jpg",
+          imageUrl: "/src/assets/Testbild.jpg",
         },
         {
           id: "4",
@@ -108,63 +109,47 @@ const Events = () => {
           imageUrl: "/assets/images/adventure.jpg",
         },
       ]);
-    }, 500); // Simulerar fördröjning vid API-anrop
+    }, 500);
 
-    return () => clearTimeout(timer); // Cleanup om komponent tas bort
+    return () => clearTimeout(timer);
   }, []);
+  
+const filteredEvents = events.filter((event) => event.status === statusFilter);
+const statusCounts = {
+  Active: events.filter(e => e.status === "Active").length,
+  Draft: events.filter(e => e.status === "Draft").length,
+  Past: events.filter(e => e.status === "Past").length
+};
 
   return (
-    <div style={{ padding: "2rem" }}>
-      {/* Titel + Vyväxling */}
-      <div
-        style={{
-          display: "flex",
-          justifyContent: "space-between",
-          alignItems: "center",
-          marginBottom: "1rem",
-        }}
-      >
-        <h1 className="h2">Alla Event</h1>
+    <div className="events-container">
+      {/* Filtreringsfältet */}
+      <EventFilters
+          viewMode={viewMode}
+          onViewModeChange={setViewMode}
+          statusFilter={statusFilter}
+          onStatusFilterChange={setStatusFilter}
+          statusCounts={statusCounts}
+      />
 
-        {/* Vyväxlare (Grid / Lista) */}
-        <div>
-          <button
-            className={`button ${
-              viewMode === "grid" ? "button-primary" : "button-secondary"
-            }`}
-            onClick={() => setViewMode("grid")}
-          >
-            Grid
-          </button>
-          <button
-            className={`button ${
-              viewMode === "list" ? "button-primary" : "button-secondary"
-            }`}
-            style={{ marginLeft: "0.5rem" }}
-            onClick={() => setViewMode("list")}
-          >
-            Lista
-          </button>
-        </div>
-      </div>
 
-      {/* Laddar... */}
-      {events.length === 0 && <p>Laddar event...</p>}
-
-      {/* Lista av EventCards */}
+      {filteredEvents.length === 0 ? (
+      <p>Inga event att visa</p>
+    ) : (
       <div className={viewMode === "grid" ? "event-grid" : "event-list"}>
-        {events.map((event) => (
-          <EventCard
-            key={event.id}
-            event={event}
-            isAdmin={true}
-            viewMode={viewMode}
-          />
-        ))}
-      </div>
+        {filteredEvents.map((event) => (
+
+            <EventCard
+              key={event.id}
+              event={event}
+              isAdmin={true}
+              viewMode={viewMode}
+            />
+          ))}
+        </div>
+      )}
     </div>
   );
 };
 
 export default Events;
-


### PR DESCRIPTION
Added a new filter bar above the Event Cards including:
- Status filters (Active, Draft, Past) with dynamic event counts.
- Search input with icon
- Icon buttons for future filter options
- Grid/List view toggles (migrated from previous header)

Functionality:
- Status filter buttons update the displayed event list.
- Grid/List toggle updates the layout.

Note:
- "This Month" and filter icon buttons are currently placeholders.
- Search input needs functionality 
- This branch builds upon `feature/event-cards`.
