### PR TITLE
Fix: Use dynamic isAdmin from AuthContext in Navbar + hide unfinished Invoices link

### DIFF
--- a/src/components/Navbar/Navbar.jsx
+++ b/src/components/Navbar/Navbar.jsx
@@ -31,9 +31,13 @@ const Navbar = () => {
               <NavLink to="/admin/bookings" className={({ isActive }) => isActive ? 'active' : ''}>
                 <CheckSquare size={18} /> Bookings
               </NavLink>
-              <NavLink to="/admin/invoices" className={({ isActive }) => isActive ? 'active' : ''}>
-                <CreditCard size={18} /> Invoices
-              </NavLink>
+              
+              {/* 
+              Tillfälligt bortkommenterad - Invoices-sidan och dess service är inte färdigställda.
+              Lägg tillbaka länken när backend och UI är klart.
+              // <NavLink to="/admin/invoices" className={({ isActive }) => isActive ? 'active' : ''}>
+              //   <CreditCard size={18} /> Invoices
+              // </NavLink> */}
             </>
           ) : (
             <>

--- a/src/components/Navbar/Navbar.jsx
+++ b/src/components/Navbar/Navbar.jsx
@@ -4,9 +4,8 @@ import { LayoutDashboard, CalendarDays, Ticket, CheckSquare, CreditCard, LogOut 
 import VentixeLogo from '../../assets/ventixe-logo.svg';
 import { useAuth } from '../../contexts/AuthContext';
 
-// TODO: Byt ut isAdmin-prop mot faktisk roll från autentisering när auth är på plats
-const Navbar = ({ isAdmin = false }) => {
-  const { signOut } = useAuth();
+const Navbar = () => {
+  const { isAdmin, signOut } = useAuth();
   const navigate = useNavigate();
 
   const handleSignOut = () => {


### PR DESCRIPTION
### Vad som ändrats

- Ersatt hårdkodad `isAdmin`-prop med dynamisk kontroll via `AuthContext`
- Navbar visar nu rätt vy beroende på inloggad användares roll
- Kommenterat bort länken till "Invoices" i admin-vyn eftersom sidan och tillhörande backend-service inte är färdigställda

### Övrigt

- Lägg gärna tillbaka `Invoices`-länken efter att backend och UI är klart
